### PR TITLE
Hear bot messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ function isDefined(obj) {
     return obj != null;
 }
 
-controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention', 'ambient'], (bot, message) => {
+controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention', 'ambient', 'bot_message'], (bot, message) => {
     try {
         if (message.type == 'message') {
             if (message.user == bot.identity.id) {


### PR DESCRIPTION
We use chat bots that send messages to Slack rooms where our API AI bot is listening. When these chat bots send messages on behalf of the users we are talking to, it is sent as a bot.

We would like API AI's chat bot to listen for the existing message types, but also bot messages. Is there anything wrong with doing that?

cc @xVir 

